### PR TITLE
Gnome Shell 40 Port

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,9 +8,10 @@
   "settings-schema": "org.gnome.shell.extensions.show-desktop-button",
   "shell-version": [
     "3.38",
-    "3.36"
+    "3.36",
+    "40.0"
   ],
   "url": "https://github.com/amivaleo/Show-Desktop-Button",
   "uuid": "show-desktop-button@amivaleo",
-  "version": 15
+  "version": 16
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,6 @@
   "name": "Show Desktop Button",
   "settings-schema": "org.gnome.shell.extensions.show-desktop-button",
   "shell-version": [
-    "3.38",
-    "3.36",
     "40.0"
   ],
   "url": "https://github.com/amivaleo/Show-Desktop-Button",

--- a/prefs.js
+++ b/prefs.js
@@ -14,7 +14,6 @@ function init () {
 function buildPrefsWidget () {
 	
 	let widget = new MyPrefsWidget();
-	widget.show_all();
 	
 	return widget;
 }
@@ -33,27 +32,17 @@ const MyPrefsWidget = new GObject.Class({
 		builder.set_translation_domain(Me.metadata['gettext-domain']);
 		builder.add_from_file(Me.path + '/prefs.ui');
 		
-		this.connect('destroy', Gtk.main_quit);
+		let currentPosition = Settings.get_enum('panel-position');
+		let comboBox = builder.get_object("panelButtonPosition_combobox");
 		
-		let SignalHandler = {
+		comboBox.set_active(currentPosition);
 		
-			panelPositionHandler (w) {
-				log(w.get_active());
-				let value = w.get_active();
-				Settings.set_enum('panel-position', value);
-			}
-	
-		};
-		
-		builder.connect_signals_full( (builder, object, signal, handler) => {
-			object.connect( signal, SignalHandler[handler].bind(this) );
+		comboBox.connect("changed", (w) => {
+		    let value = w.get_active();
+		    Settings.set_enum('panel-position', value);
 		});
 		
-		let currentPosition = Settings.get_enum('panel-position');
-		builder.get_object("panelButtonPosition_combobox").set_active(currentPosition);
-		
-		this.add(builder.get_object('main_prefs'));
+		this.set_child(builder.get_object('main_prefs'));
 	}
 
 });
-

--- a/prefs.ui
+++ b/prefs.ui
@@ -10,61 +10,53 @@
   </object>
   <object class="GtkBox" id="main_prefs">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="border-width">20</property>
     <property name="orientation">vertical</property>
+    <property name="margin_start">32</property>
+    <property name="margin_end">32</property>
+    <property name="margin_top">32</property>
+    <property name="margin_bottom">32</property>
+     
     <child>
       <object class="GtkFrame" id="frame1">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
         <property name="label-xalign">0</property>
-        <property name="shadow-type">in</property>
         <child>
           <object class="GtkListBox" id="listbox1">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
             <property name="selection-mode">none</property>
+            <property name="hexpand">1</property>
             <child>
               <object class="GtkListBoxRow" id="listboxrow2">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
+                  <property name="hexpand">1</property>
                 <child>
                   <object class="GtkBox" id="combobox_box">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="border-width">12</property>
-                    <property name="spacing">32</property>
+                    <property name="margin_start">16</property>
+                    <property name="margin_end">16</property>
+                    <property name="margin_top">16</property>
+                    <property name="margin_bottom">16</property>
+                    <property name="hexpand">1</property>
                     <child>
                       <object class="GtkLabel" id="panelButtonPosition">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
                         <property name="tooltip-text" translatable="yes">Set the position of the indicator on the top panel</property>
                         <property name="label" translatable="yes">Indicator position on panel</property>
                         <property name="xalign">0</property>
+                        <property name="hexpand">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkComboBoxText" id="panelButtonPosition_combobox">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
                         <property name="active">2</property>
                         <items>
                           <item id="0" translatable="yes">Left</item>
                           <item id="1" translatable="yes">Center</item>
                           <item id="2" translatable="yes">Right</item>
                         </items>
-                        <signal name="changed" handler="panelPositionHandler" swapped="no"/>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
@@ -73,11 +65,6 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
**prefs.js**

- _show_all()_ no longer needed on GTK4.
- No need to use destroy for prefs widget in GTK4.
- Connecting signal to the combo box directly in _prefs.js_.

**prefs.ui**

- More detailed margin properties for GTK4.
- No Packing in GTK4.
- Remove handler to directly adding that in js file.
- No needed _can-focus_ because it is true by default in GTK4.

**metadata.json**

- Removed "3.38" and "3.36" and added "40.0" to the shell version.
- Bumped the version to 16.