### PR TITLE
New GNOME Shell version checking

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "name": "Show Desktop Button",
   "settings-schema": "org.gnome.shell.extensions.show-desktop-button",
   "shell-version": [
-    "40.0"
+    "40"
   ],
   "url": "https://github.com/amivaleo/Show-Desktop-Button",
   "uuid": "show-desktop-button@amivaleo",


### PR DESCRIPTION
Since extensions website supporting major version recently,
we should only use "40" to avoid incompatibility for future minor release.