### PR TITLE
Change to metadata.json to work with Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/amivaleo/Show-Desktop-Button",
   "uuid": "show-desktop-button@amivaleo",


### PR DESCRIPTION
Changes to be committed:
 modified:   metadata.json