### PR TITLE
Update metadata.json for Gnome 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
   "name": "Show Desktop Button",
   "settings-schema": "org.gnome.shell.extensions.show-desktop-button",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/amivaleo/Show-Desktop-Button",
   "uuid": "show-desktop-button@amivaleo",


### PR DESCRIPTION
As of 46.beta I have found that adding 46 into the shell version allows Show-Desktop-Button to work of Gnome 46 with out any other intervention.