### PR TITLE
Remove debug property from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,5 +10,4 @@
   "url": "https://github.com/amivaleo/Show-Desktop-Button",
   "uuid": "show-desktop-button@amivaleo",
   "version": 52
-  "debug" : false
 }


### PR DESCRIPTION
Remove debug property from metadata.

(gnome-shell:29368): GNOME Shell-CRITICAL **: 22:41:47.980: Could not load extension show-desktop-button@amivaleo: Error: Failed to parse metadata.json: SyntaxError: JSON.parse: expected ',' or '}' after property value in object at line 13 column 3 of the JSON data